### PR TITLE
Test suite repair and better messaging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *.Rcheck/
-
 doc
 Meta
+*.gz
+

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: folderfun
-Version: 0.1.3
+Version: 0.1.4
 Date: 2020-07-14
 Title: Creates and Manages Folder Functions for Portable Large-Scale R Analysis
 Description: If you find yourself working on multiple different projects in R, you'll want a 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+# folderfun [0.1.4] -- Unreleased
+
+* Fix stochastic errors in test suite.
+* Improve test suite error messages.
+
 # folderfun [0.1.3] -- 2020-07-14
 
 * Add `failFunction` option so you can not fail on broken folder functions.

--- a/tests/check_CRAN.sh
+++ b/tests/check_CRAN.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+pkgroot=$(dirname $PWD)
+R CMD build $pkgroot
+buildfile=$(basename $pkgroot)_$1.tar.gz
+R CMD check --as-cran $buildfile
+rm $buildfile
+

--- a/tests/testthat/helper-all.R
+++ b/tests/testthat/helper-all.R
@@ -1,7 +1,6 @@
 # helper-all.R
 # Ancillary functions for setff tests
 # Author: Vince Reuter
-# Email: vpr9v@virginia.edu
 
 # Remove (set as NULL) the option this package uses to store a named variable,
 # and remove the variable storing its fetcher function.

--- a/tests/testthat/helper-all.R
+++ b/tests/testthat/helper-all.R
@@ -29,7 +29,8 @@ tomixed = function(name) {
   if (tolower(name) != name) stop("Not all lowercase: ", name)
   chars = unlist(strsplit(name, ""))
   if (length(chars) < 2) {
-    stop("Mixed-case requires at least 2 character; got ", length(chars))
+    stop(sprintf("Mixed-case requires at least 2 characters; got %s: %s", 
+      length(chars), chars))
   }
   indices = sample(1:length(chars), size = sample(1:(length(chars) - 1), size = 1))
   mixed = sapply(1:length(chars), 

--- a/tests/testthat/helper-all.R
+++ b/tests/testthat/helper-all.R
@@ -18,7 +18,7 @@ getRandVarName = function(minLen = 10, maxLen = 20) {
     minLen, maxLen))
   if (maxLen < minLen) stop(sprintf(
     "Max chars < min chars for random string: %d < %d", maxLen, minLen))
-  paste0(sample(letters, sample(minLen:maxLen)), collapse = "")
+  paste0(sample(letters, size = sample(minLen:maxLen, size = 1)), collapse = "")
 }
 
 neitherOptNorEnvVar = function(n) { stopifnot(
@@ -27,8 +27,11 @@ neitherOptNorEnvVar = function(n) { stopifnot(
 # Randomly select a subset of a name's characters to convert to uppercase
 tomixed = function(name) {
   if (tolower(name) != name) stop("Not all lowercase: ", name)
-  chars = unlist(strsplit(name, ""))    
-  indices = sample(1:length(chars), sample(1:(length(chars) - 1)))
+  chars = unlist(strsplit(name, ""))
+  if (length(chars) < 2) {
+    stop("Mixed-case requires at least 2 character; got ", length(chars))
+  }
+  indices = sample(1:length(chars), size = sample(1:(length(chars) - 1), size = 1))
   mixed = sapply(1:length(chars), 
     function(i) ifelse(i %in% indices, toupper(chars[i]), chars[i]))
   paste0(mixed, collapse="")

--- a/tests/testthat/test_setff.R
+++ b/tests/testthat/test_setff.R
@@ -1,7 +1,6 @@
 # test_setff.R
 # Tests of binding value to name.
 # Author: Vince Reuter
-# Email: vpr9v@virginia.edu
 
 context("setff")
 

--- a/tests/testthat/test_setff.R
+++ b/tests/testthat/test_setff.R
@@ -102,9 +102,7 @@ test_that("name to set can be interpreted as name of current option holding valu
 })
 
 test_that("Option lookup is case insensitive", {
-	minLen = 10
-	maxLen = 20
-	var = getRandVarName(minLen=minLen, maxLen=maxLen)
+	var = getRandVarName()
 	val = "dummy_test_val"
 	typesAlwaysFound = c("tolower", "toupper")
 	caseTypes = c("tomixed", typesAlwaysFound)
@@ -133,9 +131,7 @@ test_that("Environment variable lookup is case insensitive", {
 	# Windows and MACOS have case-insensitive file systems.
 	skip_on_os("windows")
 	skip_on_os("mac")	
-	minLen = 10
-	maxLen = 20
-	var = getRandVarName(minLen=minLen, maxLen=maxLen)
+	var = getRandVarName()
 	val = "dummy_test_val"
 	typesAlwaysFound = c("tolower", "toupper")
 	caseTypes = c("tomixed", typesAlwaysFound)
@@ -165,7 +161,7 @@ test_that("Exact name lookup precedes case variation", {
 	exactVal = "exact"
 	upperVal = "upper"
 	lowerVal = "lower"
-	for (var in sapply(1:5, getRandVarName)) {
+	for (var in sapply(1:5, function(i) { getRandVarName(i, maxLen = 5) })) {
 		mixedVar = tomixed(var)
 		upperVar = toupper(var)
 		lowerVar = tolower(var)

--- a/tests/testthat/test_setff.R
+++ b/tests/testthat/test_setff.R
@@ -161,7 +161,7 @@ test_that("Exact name lookup precedes case variation", {
 	exactVal = "exact"
 	upperVal = "upper"
 	lowerVal = "lower"
-	for (var in sapply(1:5, function(i) { getRandVarName(i, maxLen = 5) })) {
+	for (var in sapply(1:5, function(i) getRandVarName())) {
 		mixedVar = tomixed(var)
 		upperVar = toupper(var)
 		lowerVar = tolower(var)

--- a/tests/testthat/test_setff.R
+++ b/tests/testthat/test_setff.R
@@ -197,7 +197,8 @@ test_that("Exact name lookup precedes case variation", {
 			setVar(upperVar, upperVal)
 			setVar(lowerVar, lowerVal)
 			for (v in allVars) { check(v) }
-			expect_equal(setff(mixedVar)(), exactVal)
+			setVia <- function(nt) { setff(mixedVar)() }
+			expect_equal(setVia(!!nameType), exactVal)
 			for (v in allVars) {
 				clean(v)
 				neitherOptNorEnvVar(v)


### PR DESCRIPTION
This PR:
1. Fixes infrequent, random errors in the test suite related to misunderstanding the signature of `sample` and replacement of a default argument by an index variable from `sapply`. A couple code places had random events that could cause these "one-off"-looking errors. 
2. Contextualizes error messages
3. Introduces a helper script for CRAN checks; feel free to move/remove that if it belongs elsewhere or is just bad. 

Close #21 
Close #21